### PR TITLE
Updated Leaf

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,4 +15,4 @@ dependencies:
 
   - pip
   - pip:
-      - leafsim
+      - leafsim==0.4.2

--- a/simulate.py
+++ b/simulate.py
@@ -92,6 +92,8 @@ def periodic_experiment(error, max_steps_window: int = 17):
                 window_results.append(bidirectional_worker(node, jobs, ci, error, None, window))
         result[country] = window_results
 
+    if not os.path.exists("results"):
+        os.makedirs("results")
     with open(f"results/periodic_{error}.csv", "w") as csvfile:
         pd.DataFrame(result).to_csv(csvfile, index=False)
 

--- a/strategy.py
+++ b/strategy.py
@@ -48,9 +48,9 @@ class BidirectionalStrategy(Strategy):
                      f"then {self.ci[timeline_idx + wait_until]}).")
         yield env.timeout(wait_until * self.interval)
         logger.debug(f"{env.now}: Start run")
-        self.node.used_mips += 1
+        self.node.used_cu += 1
         yield env.timeout(duration)
-        self.node.used_mips -= 1
+        self.node.used_cu -= 1
         logger.debug(f"{env.now}: Finished run.")
 
 
@@ -90,9 +90,9 @@ class AdHocStrategy(Strategy):
                 last_index = index
 
                 yield env.timeout(wait_until * self.interval)
-                self.node.used_mips += 1
+                self.node.used_cu += 1
                 yield env.timeout(self.interval)
-                self.node.used_mips -= 1
+                self.node.used_cu -= 1
         else:
             # Calculate mean CI over the duration for every possible start step
             window_means = forecast.rolling(duration_steps).mean()[duration_steps - 1:]
@@ -101,9 +101,9 @@ class AdHocStrategy(Strategy):
 
             # Wait until the identified point in time and reserve the full duration
             yield env.timeout(wait_until * self.interval)
-            self.node.used_mips += 1
+            self.node.used_cu += 1
             yield env.timeout(duration)
-            self.node.used_mips -= 1
+            self.node.used_cu -= 1
 
     def _forecast_steps(self, timeline_idx: int, duration_steps: int) -> int:
         if isinstance(self.forecast, (int, float)):


### PR DESCRIPTION
- updated Leaf to version 0.4.0
- `results` dir is now created if it does not exist yet, which is the case if the repo is pulled initially. 

Edit: I see #1 already implemented similar functionality. However, as requested changes do not seem to be implemented -> closes #1. 
closes #2