### PR TITLE
added requirements.txt support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+leafsim==0.4.2
+numpy==1.24.4
+pandas==2.1.2
+scipy==1.11.3
+simpy==4.1.0
+vessim==0.3.0
+matplotlib==3.8.1
+seaborn==0.13.0


### PR DESCRIPTION
For users who do not like to use conda, or e.g. for quick cloud executions, a seperate `requirements.txt` has been added for simple python venv support.